### PR TITLE
add all information to error

### DIFF
--- a/lib/inspec/rspec_json_formatter.rb
+++ b/lib/inspec/rspec_json_formatter.rb
@@ -371,7 +371,7 @@ class InspecRspecCli < InspecRspecJson # rubocop:disable Metrics/ClassLength
       test_color = @colors[test_status]
       indicator = @indicators[x[:status]]
       indicator = @indicators['empty'] if indicator.nil?
-      msg = x[:message] || x[:skip_message] || x[:code_desc]
+      msg =  "#{x[:message]} #{x[:skip_message]} #{x[:code_desc]}"
       print_line(
         color:      test_color,
         indicator:  @indicators['small'] + indicator,


### PR DESCRIPTION
before patch error is

```
     (compared using ==)

     ✖  expected "" to match /Product created/
     Diff:
     @@ -1,2 +1,2 @@
     -/Product created/
     +""

     ✖  
     expected: 0
          got: 65

```

with patch

```
     (compared using ==)
       Command /usr/bin/testcommand --options exit_status should eq 0
     ✖  expected "" to match /Product created/
     Diff:
     @@ -1,2 +1,2 @@
     -/Product created/
     +""
       Command /usr/bin/testcommand --options
     ✖  
     expected: 0
          got: 65
```
